### PR TITLE
Fix version file URL properties

### DIFF
--- a/GameData/TrimIndicators/TrimIndicators.version
+++ b/GameData/TrimIndicators/TrimIndicators.version
@@ -1,6 +1,6 @@
 {
   "NAME": "TrimIndicators",
-  "URL": "http://ksp/spacetux.net/avc/TrimIndicators",
+  "URL": "http://ksp.spacetux.net/avc/TrimIndicators",
   "DOWNLOAD": "https://github.com/linuxgurugamer/TrimIndicators/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",

--- a/TrimIndicators.version
+++ b/TrimIndicators.version
@@ -1,6 +1,6 @@
 {
   "NAME": "TrimIndicators",
-  "URL": "http://ksp/spacetux.net/avc/TrimIndicators",
+  "URL": "http://ksp.spacetux.net/avc/TrimIndicators",
   "DOWNLOAD": "https://github.com/linuxgurugamer/TrimIndicators/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",


### PR DESCRIPTION
See linuxgurugamer/SpaceTuxLibrary#2, these URLs have a `/` where a `.` should be.

Tagging @linuxgurugamer since GitHub notifications are goofy.